### PR TITLE
Initialize AI prompt repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# AI-Coding-Prompts-And-Agents
+# AI Prompt Repository
+
+## Doel van de repository
+Deze repository is bedoeld om AI-prompts te bewaren, beheren en op te schalen voor diverse workflows. Door een uniforme structuur te hanteren, wordt samenwerken eenvoudiger en kunnen prompts efficiënt worden versiebeheerd.
+
+## Structuuropbouw
+De repository is opgedeeld in thematische mappen voor verschillende promptrollen (zoals taak-, systeem- en agent-prompts) en ondersteunende documentatie. Elke map bevat eigen richtlijnen en metadata zodat nieuwe prompts eenvoudig kunnen worden toegevoegd en gevolgd.
+
+## Nieuwe prompts toevoegen
+1. Plaats het promptbestand in de juiste map onder `prompts/`.
+2. Voeg eventuele aanvullende documentatie toe in de relevante map onder `docs/`.
+3. Voer het script `register_prompt.py` uit met de juiste invoerparameters om de prompt te registreren in `index.json`.
+4. Controleer de wijzigingen met Git en voer een commit uit.
+
+## Metadata-aanpak
+Alle prompts worden geregistreerd in `index.json`. Elke registratie bevat minimaal een unieke `id`, een `name`, een `type`, een `version`, een `description` en een lijst `tags`. Het script `register_prompt.py` vult automatisch de velden `created` en `updated`. Hierdoor ontstaat een centraal overzicht dat eenvoudig door tooling kan worden gebruikt.
+
+## Mappenoverzicht
+- `prompts/task` – prompts die taken beschrijven die moeten worden uitgevoerd.
+- `prompts/system` – systeem- of contextprompts die algemene richtlijnen bieden.
+- `prompts/master` – overkoepelende prompts die andere prompts orkestreren.
+- `prompts/validators` – prompts voor validatiemechanismen of kwaliteitscontroles.
+- `prompts/finalizers` – prompts die eindoutput verfijnen of afronden.
+- `prompts/agents` – agent-specifieke prompts voor verschillende rollen of persoonlijkheden.
+- `prompts/pipelines` – prompts die workflows of pijplijnen definiëren.
+- `docs/manuals` – handleidingen en gebruikersinstructies.
+- `docs/standards` – standaardisatie- en richtlijnbestanden.
+- `docs/changelogs` – changelogbestanden voor het bijhouden van wijzigingen.
+

--- a/docs/changelogs/README.txt
+++ b/docs/changelogs/README.txt
@@ -1,0 +1,1 @@
+Placeholder for docs/changelogs

--- a/docs/manuals/README.txt
+++ b/docs/manuals/README.txt
@@ -1,0 +1,1 @@
+Placeholder for docs/manuals

--- a/docs/standards/README.txt
+++ b/docs/standards/README.txt
@@ -1,0 +1,1 @@
+Placeholder for docs/standards

--- a/index.json
+++ b/index.json
@@ -1,0 +1,14 @@
+{
+  "prompts": [
+    {
+      "id": "",
+      "name": "",
+      "type": "",
+      "version": "",
+      "description": "",
+      "tags": [],
+      "created": "",
+      "updated": ""
+    }
+  ]
+}

--- a/prompts/agents/README.txt
+++ b/prompts/agents/README.txt
@@ -1,0 +1,1 @@
+Placeholder for prompts/agents

--- a/prompts/finalizers/README.txt
+++ b/prompts/finalizers/README.txt
@@ -1,0 +1,1 @@
+Placeholder for prompts/finalizers

--- a/prompts/master/README.txt
+++ b/prompts/master/README.txt
@@ -1,0 +1,1 @@
+Placeholder for prompts/master

--- a/prompts/pipelines/README.txt
+++ b/prompts/pipelines/README.txt
@@ -1,0 +1,1 @@
+Placeholder for prompts/pipelines

--- a/prompts/system/README.txt
+++ b/prompts/system/README.txt
@@ -1,0 +1,1 @@
+Placeholder for prompts/system

--- a/prompts/task/README.txt
+++ b/prompts/task/README.txt
@@ -1,0 +1,1 @@
+Placeholder for prompts/task

--- a/prompts/validators/README.txt
+++ b/prompts/validators/README.txt
@@ -1,0 +1,1 @@
+Placeholder for prompts/validators

--- a/register_prompt.py
+++ b/register_prompt.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Register a new prompt in index.json with validation and metadata handling."""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REQUIRED_FIELDS = ["id", "name", "type", "version", "description"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Register a new prompt in index.json")
+    parser.add_argument("--index", default="index.json", help="Pad naar index.json (standaard: index.json)")
+    parser.add_argument("--id", required=True, help="Unieke identifier voor de prompt")
+    parser.add_argument("--name", required=True, help="Naam van de prompt")
+    parser.add_argument("--type", required=True, help="Type prompt (bijv. task, system, agent)")
+    parser.add_argument("--version", required=True, help="Versienummer voor de prompt")
+    parser.add_argument("--description", required=True, help="Korte beschrijving van de prompt")
+    parser.add_argument(
+        "--tags",
+        nargs="*",
+        default=None,
+        help="Optionele lijst met tags. Meerdere tags scheiden met een spatie."
+    )
+    return parser.parse_args()
+
+
+def load_index(path: Path) -> dict:
+    if not path.exists():
+        return {"prompts": []}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Fout: bestaande index.json bevat ongeldige JSON: {exc}")
+    if "prompts" not in data or not isinstance(data["prompts"], list):
+        raise SystemExit("Fout: index.json mist een geldige 'prompts'-lijst.")
+    return data
+
+
+def validate_fields(args: argparse.Namespace) -> None:
+    missing = [field for field in REQUIRED_FIELDS if not getattr(args, field)]
+    if missing:
+        raise SystemExit(f"Fout: verplichte velden ontbreken: {', '.join(missing)}")
+
+
+def check_duplicates(prompts: list[dict], prompt_id: str) -> None:
+    for entry in prompts:
+        if entry.get("id") == prompt_id:
+            raise SystemExit(f"Fout: prompt met id '{prompt_id}' bestaat al.")
+
+
+def build_entry(args: argparse.Namespace) -> dict:
+    timestamp = datetime.now(timezone.utc).isoformat()
+    return {
+        "id": args.id,
+        "name": args.name,
+        "type": args.type,
+        "version": args.version,
+        "description": args.description,
+        "tags": args.tags if args.tags is not None else [],
+        "created": timestamp,
+        "updated": timestamp,
+    }
+
+
+def write_index(path: Path, data: dict) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+    # Validate JSON by reading it back in
+    with tmp_path.open("r", encoding="utf-8") as fh:
+        json.load(fh)
+    tmp_path.replace(path)
+
+
+def main() -> None:
+    args = parse_args()
+    index_path = Path(args.index)
+
+    validate_fields(args)
+    data = load_index(index_path)
+    prompts = data.setdefault("prompts", [])
+
+    check_duplicates(prompts, args.id)
+    entry = build_entry(args)
+    prompts.append(entry)
+
+    write_index(index_path, data)
+    print(f"Prompt '{args.id}' succesvol geregistreerd in {index_path}.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit as exc:
+        print(exc, file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- set up prompts and documentation directories with placeholder files
- add a comprehensive README describing repository purpose and usage
- include an index.json template and a register_prompt.py script for prompt metadata management

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175f97db888327ac450ce812139500)